### PR TITLE
Add Header List Macro

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -313,3 +313,15 @@ impl StompHeaderSet for HeaderList {
 
 }
 
+#[macro_export]
+macro_rules! header_list [
+
+  ($($header: expr), *) => ({
+    let mut header_list = HeaderList::new();
+
+    $(header_list.push($header);)*
+
+    header_list
+  })
+
+];


### PR DESCRIPTION
A new macro to create header lists eliminates code specially from applications using the low-level API