### PR TITLE
Subscription trait

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -46,7 +46,7 @@ impl Connection {
     (heartbeat_tx_ms, heartbeat_rx_ms)
   }
 
-  pub fn start_session(mut self, client_tx_ms: u32, client_rx_ms: u32) -> IoResult<Session> {
+  pub fn start_session<'a>(mut self, client_tx_ms: u32, client_rx_ms: u32) -> IoResult<Session<'a>> {
     let connect_frame = Frame::connect(client_tx_ms, client_rx_ms);
     let (server_tx_ms, server_rx_ms) = try!(self.start_session_with_frame(connect_frame));
     let (tx_ms, rx_ms) = Connection::select_heartbeat(client_tx_ms, client_rx_ms, server_tx_ms, server_rx_ms);
@@ -54,7 +54,7 @@ impl Connection {
     Ok(session)
   }
 
-  pub fn start_session_with_credentials(mut self, login: &str, passcode: &str, client_tx_ms: u32, client_rx_ms: u32) -> IoResult<Session> {
+  pub fn start_session_with_credentials<'a>(mut self, login: &str, passcode: &str, client_tx_ms: u32, client_rx_ms: u32) -> IoResult<Session<'a>> {
     let mut connect_frame = Frame::connect(client_tx_ms, client_rx_ms);
     connect_frame.headers.push(
       Header::encode_key_value("login", login)

--- a/src/session.rs
+++ b/src/session.rs
@@ -13,7 +13,7 @@ use subscription::AckMode;
 use subscription::AckMode::{Auto, Client, ClientIndividual};
 use subscription::AckOrNack;
 use subscription::AckOrNack::{Ack, Nack};
-use subscription::{Subscription, SubscriptionHandler};
+use subscription::{Subscription, MessageHandler};
 use frame::Frame;
 use frame::Transmission;
 use frame::Transmission::{HeartBeat, CompleteFrame};
@@ -224,7 +224,7 @@ impl <'a> Session <'a> {
     Ok(())
   }
 
-  pub fn subscribe<S>(&mut self, topic: &str, ack_mode: AckMode, handler : S)-> IoResult<String> where S : SubscriptionHandler + 'a {
+  pub fn subscribe<S>(&mut self, topic: &str, ack_mode: AckMode, handler : S)-> IoResult<String> where S : MessageHandler + 'a {
     let next_id = self.generate_subscription_id();
     let sub = Subscription::new(next_id, topic, ack_mode, handler);
     let subscribe_frame = Frame::subscribe(sub.id.as_slice(), sub.topic.as_slice(), ack_mode);

--- a/src/stomp.rs
+++ b/src/stomp.rs
@@ -11,20 +11,20 @@ use std::io::IoResult;
 use session::Session;
 use connection::Connection;
 
-pub fn connect(ip_address: &str, port: u16) -> IoResult<Session> {
+pub fn connect<'a>(ip_address: &str, port: u16) -> IoResult<Session<'a>> {
   connect_with_heartbeat(ip_address, port, 0, 0)
 }
 
-pub fn connect_with_heartbeat(ip_address: &str, port: u16, tx_heartbeat_ms: u32, rx_heartbeat_ms: u32) -> IoResult<Session> {
+pub fn connect_with_heartbeat<'a>(ip_address: &str, port: u16, tx_heartbeat_ms: u32, rx_heartbeat_ms: u32) -> IoResult<Session<'a>> {
   let connection = try!(Connection::new(ip_address, port));
   connection.start_session(tx_heartbeat_ms, rx_heartbeat_ms)
 }
 
-pub fn connect_with_credentials(ip_address: &str, port: u16, login: &str, passcode: &str) -> IoResult<Session> {
+pub fn connect_with_credentials<'a>(ip_address: &str, port: u16, login: &str, passcode: &str) -> IoResult<Session<'a>> {
   connect_with_credentials_and_heartbeat(ip_address, port, login, passcode, 0, 0)
 }
 
-pub fn connect_with_credentials_and_heartbeat(ip_address: &str, port: u16, login: &str, passcode: &str, tx_heartbeat_ms: u32, rx_heartbeat_ms: u32) -> IoResult<Session> {
+pub fn connect_with_credentials_and_heartbeat<'a>(ip_address: &str, port: u16, login: &str, passcode: &str, tx_heartbeat_ms: u32, rx_heartbeat_ms: u32) -> IoResult<Session<'a>> {
   let connection = try!(Connection::new(ip_address, port));
   connection.start_session_with_credentials(login, passcode, tx_heartbeat_ms, rx_heartbeat_ms)
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -23,7 +23,7 @@ pub enum AckOrNack {
   Nack
 }
 
-pub trait SubscriptionHandler {
+pub trait MessageHandler {
   fn on_message(&mut self, &Frame) -> AckOrNack;
 }
 
@@ -31,11 +31,11 @@ pub struct Subscription <'a> {
   pub id : String,
   pub topic: String,
   pub ack_mode: AckMode,
-  pub handler: Box<SubscriptionHandler + 'a>
+  pub handler: Box<MessageHandler + 'a>
 }
 
 impl <'a> Subscription <'a> {
-  pub fn new<S>(id: u32, topic: &str, ack_mode: AckMode, handler: S) -> Subscription <'a> where S : SubscriptionHandler + 'a {
+  pub fn new<S>(id: u32, topic: &str, ack_mode: AckMode, handler: S) -> Subscription <'a> where S : MessageHandler + 'a {
     Subscription {
       id: format!("stomp-rs/{}",id),
       topic: topic.to_string(),

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -17,27 +17,30 @@ impl AckMode {
   }
 }
 
-
 #[derive(Copy)]
 pub enum AckOrNack {
   Ack,
   Nack
 }
 
-pub struct Subscription {
+pub trait SubscriptionHandler {
+  fn on_message(&mut self, &Frame) -> AckOrNack;
+}
+
+pub struct Subscription <'a> { 
   pub id : String,
   pub topic: String,
   pub ack_mode: AckMode,
-  pub callback: fn(&Frame)-> AckOrNack
+  pub handler: Box<SubscriptionHandler + 'a>
 }
 
-impl Subscription {
-  pub fn new(id: u32, topic: &str, ack_mode: AckMode, callback: fn(&Frame)->AckOrNack) -> Subscription {
+impl <'a> Subscription <'a> {
+  pub fn new<S>(id: u32, topic: &str, ack_mode: AckMode, handler: S) -> Subscription <'a> where S : SubscriptionHandler + 'a {
     Subscription {
       id: format!("stomp-rs/{}",id),
       topic: topic.to_string(),
       ack_mode: ack_mode,
-      callback: callback 
+      handler: Box::new(handler)
     }
   }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -21,7 +21,6 @@ impl <'a, 'b> Transaction<'a, 'b> {
     send_frame.headers.push(
       Header::encode_key_value("transaction", self.id.as_slice())
     );
-    //Ok(try!(self.session.send(send_frame)))
     Ok(self.session.send(send_frame))
   }
 
@@ -31,19 +30,16 @@ impl <'a, 'b> Transaction<'a, 'b> {
 
   pub fn begin(&mut self) -> IoResult<()> {
     let begin_frame = Frame::begin(self.id.as_slice());
-    //Ok(try!(self.session.send(begin_frame)))
     Ok(self.session.send(begin_frame))
   }
 
   pub fn commit(&mut self) -> IoResult<()> {
     let commit_frame = Frame::commit(self.id.as_slice());
-    //Ok(try!(self.session.send(commit_frame)))
     Ok(self.session.send(commit_frame))
   }
 
   pub fn abort(&mut self) -> IoResult<()> {
     let abort_frame = Frame::abort(self.id.as_slice());
-    //Ok(try!(self.session.send(abort_frame)))
     Ok(self.session.send(abort_frame))
   }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -3,13 +3,13 @@ use std::io::IoResult;
 use header::Header;
 use session::Session;
 
-pub struct Transaction<'a> {
+pub struct Transaction<'a, 'b: 'a> {
   pub id: String, 
-  pub session: &'a mut Session
+  pub session: &'a mut Session<'b>
 }
 
-impl <'a> Transaction<'a> {
-  pub fn new(id: u32, session: &'a mut Session) -> Transaction<'a> {
+impl <'a, 'b> Transaction<'a, 'b> {
+  pub fn new(id: u32, session: &'a mut Session<'b>) -> Transaction<'a, 'b> {
     Transaction {
       id: format!("tx/{}",id),
       session: session,


### PR DESCRIPTION
Introduces `MessageHandler` trait which replaces the use of bare functions in subscriptions. This allows for stateful handling of messages.