### PR TITLE
Update for ostensible changes in lifetime handling in rustc.

### DIFF
--- a/src/option_setter.rs
+++ b/src/option_setter.rs
@@ -88,7 +88,7 @@ impl <'a, 'session, T> OptionSetter<MessageBuilder<'a, 'session>> for ReceiptHan
   fn set_option(self, mut builder: MessageBuilder<'a, 'session>) -> MessageBuilder<'a, 'session> {
     let next_id = builder.session.generate_receipt_id();
     let receipt_id = format!("message/{}", next_id);
-    let ReceiptHandler(handler_convertible) = self;
+    let handler_convertible = self.handler;
     let handler = handler_convertible.to_frame_handler();
     builder.frame.headers.push(Header::new("receipt", receipt_id.as_slice())); 
     builder.session.receipt_handlers.insert(receipt_id.to_string(), handler);;
@@ -100,7 +100,7 @@ impl <'a, 'session, 'sub, T> OptionSetter<SubscriptionBuilder<'a, 'session, 'sub
   fn set_option(self, mut builder: SubscriptionBuilder<'a, 'session, 'sub>) -> SubscriptionBuilder<'a, 'session, 'sub> {
     let next_id = builder.session.generate_receipt_id();
     let receipt_id = format!("message/{}", next_id);
-    let ReceiptHandler(handler_convertible) = self;
+    let handler_convertible = self.handler;
     let handler = handler_convertible.to_frame_handler();
     builder.headers.push(Header::new("receipt", receipt_id.as_slice())); 
     builder.session.receipt_handlers.insert(receipt_id.to_string(), handler);;

--- a/src/session.rs
+++ b/src/session.rs
@@ -9,6 +9,7 @@ use std::old_io::IoResult;
 use std::old_io::IoError;
 use std::old_io::IoErrorKind::{ConnectionFailed};
 use std::old_io::net::tcp::TcpStream;
+use std::marker::PhantomData;
 use connection::Connection;
 use subscription::AckMode;
 use subscription::AckMode::{Auto, Client, ClientIndividual};
@@ -47,7 +48,17 @@ impl <'a, T: 'a> ToFrameHandler <'a> for T where T: FrameHandler {
   }
 }
 
-pub struct ReceiptHandler<'a, T>(pub T) where T: ToFrameHandler<'a>;
+pub struct ReceiptHandler<'a, T> where T: 'a + ToFrameHandler<'a> {
+  pub handler: T,
+  _marker: PhantomData<&'a T>
+}
+
+impl<'a, T> ReceiptHandler<'a, T> where T: 'a + ToFrameHandler<'a> {
+  pub fn new(val: T) -> ReceiptHandler<'a T> {
+    let r = ReceiptHandler { handler: val, _marker: PhantomData };
+    r
+  }
+}
 
 pub struct Session <'a> { 
   pub connection : Connection,


### PR DESCRIPTION
Hi.

Whilst I'm not 100% sure of exactly sure of the cause, it looks like this library doesn't build on current -nightly rust builds, seemingly due to changes in lifetime handling. It looks like it's a simple fix, but I'm happy to discuss it.

Thanks for the library.